### PR TITLE
Bump requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.22.0
+requests>=2.22.0


### PR DESCRIPTION
To allow for `urllib3>=1.26.5` , see https://github.com/advisories/GHSA-q2q7-5pp4-w6pg